### PR TITLE
Fix kernel panic on Broadwell-E/MB. No integrated graphics.

### DIFF
--- a/CPUSensors/CPUSensors.cpp
+++ b/CPUSensors/CPUSensors.cpp
@@ -820,15 +820,22 @@ bool CPUSensors::start(IOService *provider)
                 
                 // Uncore sensor is only available on CPUs with uncore device (built-in GPU)
                 switch (cpuid_info()->cpuid_model) {
-                    case CPUID_MODEL_JAKETOWN:
-                    case CPUID_MODEL_IVYBRIDGE_EP:
-                    case CPUID_MODEL_HASWELL_MB:
-                        // Do not add uncore sensor
+                    case CPUID_MODEL_SANDYBRIDGE:
+                    case CPUID_MODEL_NEHALEM_EX:
+                    case CPUID_MODEL_IVYBRIDGE:
+                    case CPUID_MODEL_HASWELL_DT:
+                    case CPUID_MODEL_HASWELL_ULT:
+                    case CPUID_MODEL_HASWELL_ULX:
+                    case CPUID_MODEL_BROADWELL_DT:
+                    case CPUID_MODEL_BROADWELL_ULV:
+                    case CPUID_MODEL_SKYLAKE_LT:
+                    case CPUID_MODEL_SKYLAKE_DT:
+                        if (!addSensor(KEY_CPU_PACKAGE_GFX_POWER, TYPE_SP78, TYPE_SPXX_SIZE, kCPUSensorsPowerUncore, 2))
+                            HWSensorsWarningLog("failed to add CPU package uncore power sensor");
                         break;
 
                     default:
-                        if (!addSensor(KEY_CPU_PACKAGE_GFX_POWER, TYPE_SP78, TYPE_SPXX_SIZE, kCPUSensorsPowerUncore, 2))
-                            HWSensorsWarningLog("failed to add CPU package uncore power sensor");
+                        // Do not add uncore sensor
                         break;
                 }
 


### PR DESCRIPTION
Only specific CPU models have integrated graphics. Broadwell-MB does not. This unfortunately was not noted in the Broadwell support patches. So, on my 6950X, it would try to read the uncore sensor and kernel panic on the update_counters call.

The uncore sensor support should be explicitly added vs added by default. The failure case when there is no uncore sensor is a kernel panic.

This patch reverses the logic. Instead of opting out various models, it opts in models with the intel Iris graphics. So if a new CPU model comes along, the kext won't require a recompile in case it doesn't have an uncore device. With this patch, the failure case is simply no uncore sensor support.