### PR TITLE
LPCSensors: Added support for NCT6795D

### DIFF
--- a/SuperIOSensors/LPCSensors-Info.plist
+++ b/SuperIOSensors/LPCSensors-Info.plist
@@ -2978,6 +2978,7 @@
 				<string>Nuvoton,NCT6791D</string>
 				<string>Nuvoton,NCT6792D</string>
 				<string>Nuvoton,NCT6793D</string>
+				<string>Nuvoton,NCT6795D</string>
 			</array>
 			<key>IOProviderClass</key>
 			<string>SuperIODevice</string>

--- a/SuperIOSensors/NCT677xSensors.cpp
+++ b/SuperIOSensors/NCT677xSensors.cpp
@@ -106,6 +106,7 @@ float NCT677xSensors::readTemperature(UInt32 index)
             case NCT6791D:
             case NCT6792D:
             case NCT6793D:
+            case NCT6795D:
                 value = readByte(NUVOTON_TEMPERATURE_REG_NEW[index]) << 1;
                 break;
         }
@@ -135,6 +136,7 @@ float NCT677xSensors::readVoltage(UInt32 index)
             case NCT6791D:
             case NCT6792D:
             case NCT6793D:
+            case NCT6795D:
                 value = readByte(NUVOTON_VOLTAGE_REG_NEW[index]) * NUVOTON_VOLTAGE_SCALE[index] * 0.001f;
                 break;
         }
@@ -266,6 +268,7 @@ bool NCT677xSensors::initialize()
         case NCT6791D:
         case NCT6792D:
         case NCT6793D:
+        case NCT6795D:
             fanLimit = 6;
             tempLimit = 7;
             voltLimit = 15;
@@ -288,7 +291,8 @@ void NCT677xSensors::hasPoweredOn()
     switch (model) {
         case NCT6791D:
         case NCT6792D:
-        case NCT6793D: {
+        case NCT6793D:
+        case NCT6795D: {
             // disable the hardware monitor i/o space lock on NCT679xD chips
             winbond_family_enter(port);
 

--- a/SuperIOSensors/SuperIODevice.cpp
+++ b/SuperIOSensors/SuperIODevice.cpp
@@ -186,6 +186,15 @@ bool SuperIODevice::detectWinbondFamilyChip()
                                 break;
                         } break;
 
+                    case 0xD3:
+                        switch (id & 0xff) {
+                            case 0x52:
+                                model = NCT6795D;
+                                ldn = kWinbondHardwareMonitorLDN;
+                                vendor = "Nuvoton";
+                                break;
+                        } break;
+
                 } break;
         }
         

--- a/SuperIOSensors/SuperIODevice.h
+++ b/SuperIOSensors/SuperIODevice.h
@@ -80,7 +80,8 @@ enum SuperIOModel
     NCT6779D    = 0xC560,
     NCT6791D    = 0xC803,
     NCT6792D    = 0xC911,
-    NCT6793D    = 0xD121
+    NCT6793D    = 0xD121,
+    NCT6795D    = 0xD352
 };
 
 inline UInt8 superio_listen_port_byte(i386_ioport_t port, UInt8 reg)

--- a/SuperIOSensors/SuperIODevice.h
+++ b/SuperIOSensors/SuperIODevice.h
@@ -183,6 +183,7 @@ inline const char* superio_get_model_name(UInt16 model)
         case NCT6791D:      return "NCT6791D";
         case NCT6792D:      return "NCT6792D";
         case NCT6793D:      return "NCT6793D";
+        case NCT6795D:      return "NCT6795D";
     }
     
     return "unknown";


### PR DESCRIPTION
The Super I/O chip NCT6795D was found on a MSI Z270-A PRO mainboard.