### PR TITLE
Add support for Vega 10

### DIFF
--- a/GPUSensors/RadeonSensors/RadeonSensors.cpp
+++ b/GPUSensors/RadeonSensors/RadeonSensors.cpp
@@ -18,6 +18,7 @@
 #include "si.h"
 #include "cik.h"
 #include "evergreen.h"
+#include "vega.h"
 
 #include "smc.h"
 
@@ -223,6 +224,9 @@ bool RadeonSensors::managedStart(IOService *provider)
                  !strncasecmp("HAINAN", card.bios_name, 64)) {
             card.int_thermal_type = THERMAL_TYPE_SI;
         }
+        else if (!strncasecmp("VEGA10", card.bios_name, 64)) {
+            card.int_thermal_type = THERMAL_TYPE_VEGA;
+        }
     }
     
     // Use driver's configuration to resolve temperature sensor type
@@ -322,6 +326,10 @@ bool RadeonSensors::managedStart(IOService *provider)
             case THERMAL_TYPE_KV:
                 card.get_core_temp = kv_get_temp;
                 radeon_info(&card, "adding Sea Islands (Kaveri) thermal sensor\n");
+                break;
+            case THERMAL_TYPE_VEGA:
+                card.get_core_temp = vega_get_temp;                
+                radeon_info(&card, "adding Vega thermal sensor\n");
                 break;
             default:
                 radeon_fatal(&card, "card 0x%04x is unsupported\n", card.chip_id & 0xffff);

--- a/GPUSensors/RadeonSensors/radeon.h
+++ b/GPUSensors/RadeonSensors/radeon.h
@@ -44,6 +44,7 @@ enum radeon_int_thermal_type {
 	THERMAL_TYPE_EMC2103_WITH_INTERNAL,
 	THERMAL_TYPE_CI,
 	THERMAL_TYPE_KV,
+    THERMAL_TYPE_VEGA,
 };
 
 typedef struct {

--- a/GPUSensors/RadeonSensors/vega.cpp
+++ b/GPUSensors/RadeonSensors/vega.cpp
@@ -1,0 +1,49 @@
+//
+//  vega.c
+//  HWSensors
+//
+//  Created by Tobias Punke on 02.02.2018.
+//
+//
+
+#include "vega.h"
+#include "radeon_definitions.h"
+
+#include <IOKit/IOLib.h>
+#include <IOKit/pci/IOPCIDevice.h>
+
+//VEGA10
+#define THM_TCON_CUR_TMP                      0x59800
+#define THM_TCON_CUR_TMP__CUR_TEMP__SHIFT     24
+
+int vega_get_temp(struct radeon_device *rdev)
+{
+    // I don't know what I am doing...
+    IOMemoryMap * mmio5 = NULL;
+    IOMemoryDescriptor * theDescriptor;
+    IOPhysicalAddress bar = (IOPhysicalAddress)((rdev->pdev->configRead32(kIOPCIConfigBaseAddress5)) & ~0x3f);
+    
+    theDescriptor = IOMemoryDescriptor::withPhysicalAddress (bar, 0x80000, kIODirectionOutIn);
+    
+    if(theDescriptor != NULL)
+    {
+        mmio5 = theDescriptor->map();
+    }
+    
+    IOMemoryMap * mmio = NULL;
+    volatile UInt8* mmio_base;
+    
+    if (mmio5 && mmio5->getPhysicalAddress() != 0)
+    {
+        mmio = mmio5;
+        mmio_base = (volatile UInt8 *)mmio->getVirtualAddress();
+    }
+    
+    // Finally: temp retrieval
+    UInt32 temp, actual_temp = 0;
+    temp = OSReadLittleInt32(((volatile UInt8 *)mmio_base), THM_TCON_CUR_TMP) >> THM_TCON_CUR_TMP__CUR_TEMP__SHIFT;
+    actual_temp = temp & 0x1ff;
+    
+    return actual_temp;
+}
+

--- a/GPUSensors/RadeonSensors/vega.h
+++ b/GPUSensors/RadeonSensors/vega.h
@@ -1,0 +1,49 @@
+//
+//  vega.h
+//  HWSensors
+//
+//  Created by Tobias Punke on 02.02.2018.
+//
+//
+
+/*
+ * Copyright 2008 Advanced Micro Devices, Inc.
+ * Copyright 2008 Red Hat Inc.
+ * Copyright 2009 Jerome Glisse.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Authors: Dave Airlie
+ *          Alex Deucher
+ *          Jerome Glisse
+ */
+
+#ifndef HWSensors_vega_h
+#define HWSensors_vega_h
+
+#include "radeon.h"
+
+//#define     RREG32_SMC(reg)             tn_smc_rreg(rdev, (reg))
+//#define     TN_SMC_IND_INDEX_0          0x200
+//#define     TN_SMC_IND_DATA_0           0x204
+
+int vega_get_temp(struct radeon_device *rdev);
+
+#endif
+

--- a/HWSensors.xcodeproj/project.pbxproj
+++ b/HWSensors.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		7EBEB1DB17B1754D00C114B5 /* GPUSensors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7EBEB1D917B1754D00C114B5 /* GPUSensors.cpp */; };
 		7ECCB63E18537A7000D95FB4 /* cik.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7ECCB63D18537A7000D95FB4 /* cik.cpp */; };
 		7EDFC7581E05A9F3005A6F96 /* gp100.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7EDFC7561E05A9F3005A6F96 /* gp100.cpp */; };
+		F6D276032023D87B00D392E1 /* vega.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6D276022023D87B00D392E1 /* vega.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -242,6 +243,8 @@
 		7EFF9518182AD44700C637C8 /* FakeSMCKeyStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FakeSMCKeyStore.h; path = FakeSMCKeyStore/FakeSMCKeyStore.h; sourceTree = SOURCE_ROOT; };
 		7EFF9519182AD44700C637C8 /* FakeSMCKeyStoreUserClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FakeSMCKeyStoreUserClient.cpp; path = FakeSMCKeyStore/FakeSMCKeyStoreUserClient.cpp; sourceTree = SOURCE_ROOT; };
 		7EFF951A182AD44700C637C8 /* FakeSMCKeyStoreUserClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FakeSMCKeyStoreUserClient.h; path = FakeSMCKeyStore/FakeSMCKeyStoreUserClient.h; sourceTree = SOURCE_ROOT; };
+		F6D276012023D76700D392E1 /* vega.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = vega.h; sourceTree = "<group>"; };
+		F6D276022023D87B00D392E1 /* vega.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = vega.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -524,6 +527,8 @@
 				7E138D89169A90D3007BE068 /* evergreend.h */,
 				7E0EB893169A9C4D000DF2B1 /* evergreen.h */,
 				7E0EB890169A9A9A000DF2B1 /* evergreen.cpp */,
+				F6D276012023D76700D392E1 /* vega.h */,
+				F6D276022023D87B00D392E1 /* vega.cpp */,
 			);
 			name = radeon;
 			sourceTree = "<group>";
@@ -973,6 +978,7 @@
 				7ECCB63E18537A7000D95FB4 /* cik.cpp in Sources */,
 				7E9F54B4167C71DA006E907B /* nvd0.cpp in Sources */,
 				7E9F54B6167C71DA006E907B /* nve0.cpp in Sources */,
+				F6D276032023D87B00D392E1 /* vega.cpp in Sources */,
 				7E9F54B8167C71DA006E907B /* vga.cpp in Sources */,
 				7E9F54BA167C71DA006E907B /* w83781d.cpp in Sources */,
 				7E9F54BB167C71DA006E907B /* w83l785r.cpp in Sources */,


### PR DESCRIPTION
Card identification is done by looking at the BIOS name. I am no C or kernel expert, so I added the thermal retrieval into separate files (vega.h and vga.cpp). This way it will not pollute the code base. The effective, thermal calculating code is from slice2009, he is maintaining a fork of FakeSMC [here](https://sourceforge.net/projects/hwsensors3.hwsensors.p/). Again, I do not really know what I am doing, I am mainly a C# developer - so if you have suggestions to make: they are very welcome. Works on my Saphire Vega 64 XTX LCE.